### PR TITLE
Error while importing CA certificate:

### DIFF
--- a/src/dispatcher/plugins/CryptoPlugin.py
+++ b/src/dispatcher/plugins/CryptoPlugin.py
@@ -87,7 +87,7 @@ def load_certificate(buf):
     cert_info['common'] = cert.get_subject().CN
     cert_info['email'] = cert.get_subject().emailAddress
 
-    signature_algorithm = cert.get_signature_algorithm()
+    signature_algorithm = cert.get_signature_algorithm().decode('utf-8')
     m = re.match('^(.+)[Ww]ith', signature_algorithm)
     if m:
         cert_info['digest_algorithm'] = m.group(1).upper()


### PR DESCRIPTION
Hi,

I've tried to import CA cert and the following error appeared :

...Or I've used dispatcher client in the worng way ;) 


/usr/local/lib/dispatcher/plugins/CryptoPlugin.py", line 91, in load_certificate\n    m = re.match(\'^(.+)[Ww]ith\', signature_algorithm)\n  File "/usr/local/lib/python3.4/re.py", line 160, in match\n    return _compile(pattern, flags).match(string)\nTypeError: can\'t use a string pattern on a bytes-like object\n