### PR TITLE
CryptoPlugin schema should include 'passphrase' property

### DIFF
--- a/src/dispatcher/plugins/CryptoPlugin.py
+++ b/src/dispatcher/plugins/CryptoPlugin.py
@@ -477,6 +477,7 @@ def _init(dispatcher, plugin):
             'state': {'type': 'string'},
             'city': {'type': 'string'},
             'organization': {'type': 'string'},
+            'passphrase': {'type': ['string', 'null']},
             'email': {'type': 'string'},
             'common': {'type': 'string'},
             'serial': {'type': ['integer', 'null']},


### PR DESCRIPTION
CryptoPlugin schema should include 'passphrase' property, otherwise it is not possible to import a password protected private key. 