### PR TITLE
error message for reloading stopped service

### DIFF
--- a/src/dispatcher/plugins/ServiceManagePlugin.py
+++ b/src/dispatcher/plugins/ServiceManagePlugin.py
@@ -337,6 +337,9 @@ class ServiceManageTask(Task):
         if state == 'STOPPED' and action == 'stop':
             return
 
+        if state != 'RUNNING' and action == 'reload':
+            raise TaskException(errno.EINVAL, 'Only running services can be reloaded')
+
         if hook_rpc:
             try:
                 return self.dispatcher.call_sync(hook_rpc)


### PR DESCRIPTION
Added error message when 'reload' command is executed on non-running service

Ticket: #13704