### PR TITLE
Better error messages + RuntimeError changed for the better error propagation

### DIFF
--- a/src/containerd/src/main.py
+++ b/src/containerd/src/main.py
@@ -1193,7 +1193,7 @@ class ManagementService(RpcService):
     def call_vmtools(self, id, fn, *args):
         vm = self.context.vms.get(id)
         if not vm:
-            raise RpcException(errno.ENOENT, 'It looks like the VM is not runnig - please start the VM')
+            return
 
         return vm.call_vmtools(fn, *args)
 

--- a/src/containerd/src/main.py
+++ b/src/containerd/src/main.py
@@ -389,7 +389,7 @@ class VirtualMachine(object):
 
     def call_vmtools(self, method, *args, timeout=None):
         if not self.vmtools_ready:
-            raise RuntimeError('freenas-vm-tools service not ready or not present')
+            raise RpcException(errno.ENXIO, 'freenas-vm-tools service not ready or not present')
 
         return self.vmtools_client.call_sync(method, *args, timeout=timeout)
 
@@ -1193,7 +1193,7 @@ class ManagementService(RpcService):
     def call_vmtools(self, id, fn, *args):
         vm = self.context.vms.get(id)
         if not vm:
-            raise RpcException(errno.ENOENT, 'VM {0} not found'.format(id))
+            raise RpcException(errno.ENOENT, 'It looks like the VM is not runnig - please start the VM')
 
         return vm.call_vmtools(fn, *args)
 

--- a/src/dispatcher/plugins/VMPlugin.py
+++ b/src/dispatcher/plugins/VMPlugin.py
@@ -208,10 +208,11 @@ class VMProvider(Provider):
         interfaces = self.dispatcher.call_sync('containerd.management.call_vmtools', id, 'network.interfaces')
         loadavg = self.dispatcher.call_sync('containerd.management.call_vmtools', id, 'system.loadavg')
 
-        return {
-            'interfaces': interfaces,
-            'load_avg': list(loadavg)
-        }
+        if interfaces and loadavg:
+            return {
+                'interfaces': interfaces,
+                'load_avg': list(loadavg)
+            }
 
     @accepts(str, str)
     @returns(h.object())


### PR DESCRIPTION
Without this changes UI experience looks like this:

unix::/vm/ubuntu-cloud14>guest_info
Error: ENOENT: VM 494376a3-b15e-43ef-936f-53c9bb63a8c4 not found


unix::/vm/debian>guest_info
Error: EFAULT: Traceback (most recent call last):
  File "/usr/local/lib/python3.4/site-packages/freenas/dispatcher/rpc.py", line 172, in dispatch_call
    result = func(*args)
  File "/usr/local/lib/containerd/src/main.py", line 1198, in call_vmtools
    return vm.call_vmtools(fn, *args)
  File "/usr/local/lib/containerd/src/main.py", line 392, in call_vmtools
    raise RuntimeError('freenas-vm-tools service not ready or not present')
RuntimeError: freenas-vm-tools service not ready or not present
