### PR TITLE
Allow "service changed" events to propagate for the RPC based services

### DIFF
--- a/src/dispatcher/plugins/ServiceManagePlugin.py
+++ b/src/dispatcher/plugins/ServiceManagePlugin.py
@@ -248,7 +248,7 @@ class ServiceManageTask(Task):
 
         if hook_rpc:
             try:
-                return self.dispatcher.call_sync(hook_rpc)
+                self.dispatcher.call_sync(hook_rpc)
             except RpcException as e:
                 raise TaskException(errno.EBUSY, 'Hook {0} for {1} failed: {2}'.format(
                     action, name, e


### PR DESCRIPTION
Without this UI is not going to receive needed events.
btw. Leaving this that way it is possible to define dispatcher RPC that is going to be fired before serviced tasks.