### PR TITLE
container and network create/connect in one command

### DIFF
--- a/src/containerd/src/main.py
+++ b/src/containerd/src/main.py
@@ -1758,7 +1758,7 @@ class DockerService(RpcService):
             if err.code == errno.ENOENT:
                 self.context.client.emit_event('containerd.docker.container.changed', {
                     'operation': 'delete',
-                    'ids': id
+                    'ids': [id]
                 })
                 return
         try:
@@ -1773,7 +1773,7 @@ class DockerService(RpcService):
             if err.code == errno.ENOENT:
                 self.context.client.emit_event('containerd.docker.network.changed', {
                     'operation': 'delete',
-                    'ids': id
+                    'ids': [id]
                 })
                 return
         try:

--- a/src/containerd/src/main.py
+++ b/src/containerd/src/main.py
@@ -1000,9 +1000,17 @@ class DockerHost(object):
                         })
 
                     if ev['Type'] == 'network':
+                        netw_id = q.get(ev, 'Actor.ID')
+                        cont_id = q.get(ev, 'Actor.Attributes.container')
+                        operation = actions.get(ev['Action'], 'update')
+                        if cont_id:
+                            self.context.client.emit_event('containerd.docker.container.changed', {
+                                'operation': operation,
+                                'ids': [cont_id]
+                            })
                         self.context.client.emit_event('containerd.docker.network.changed', {
-                            'operation': actions.get(ev['Action'], 'update'),
-                            'ids': [ev['Actor']['ID']]
+                            'operation': operation,
+                            'ids': [netw_id]
                         })
 
                 self.logger.warning('Disconnected from Docker API endpoint on {0}'.format(self.vm.name))

--- a/src/dispatcher/plugins/DockerPlugin.py
+++ b/src/dispatcher/plugins/DockerPlugin.py
@@ -2087,6 +2087,10 @@ def _init(dispatcher, plugin):
                 'items': {'type': 'string'}
             },
             'privileged': {'type': 'boolean'},
+            'networks': {
+                'type': 'array',
+                'items': {'type': 'string'}
+            }
         }
     })
 

--- a/src/dispatcher/plugins/DockerPlugin.py
+++ b/src/dispatcher/plugins/DockerPlugin.py
@@ -1021,30 +1021,30 @@ class DockerNetworkDeleteTask(DockerBaseTask):
         )
 
 
-@description('Connects container to a network')
-@accepts(str, str)
+@description('Connects selected containers to a network')
+@accepts(h.array(str), str)
 class DockerNetworkConnectTask(DockerBaseTask):
     @classmethod
     def early_describe(cls):
-        return 'Connecting container to network'
+        return 'Connecting containers to network'
 
-    def describe(self, container_id, network_id):
-        contname = self.dispatcher.call_sync(
-            'docker.container.query', [('id', '=', container_id)], {'single': True, 'select': 'names.0'}
+    def describe(self, container_ids, network_id):
+        contnames = self.dispatcher.call_sync(
+            'docker.container.query', [('id', 'in', container_ids)], {'select': 'name'}
         )
         netname = self.dispatcher.call_sync(
             'docker.network.query', [('id', '=', network_id)], {'single': True, 'select': 'name'}
         )
-        return TaskDescription('Connecting container {contname} to network {netname}',
-                               contname=contname or container_id,
+        return TaskDescription('Connecting containers {contnames} to network {netname}',
+                               contnames=','.join(contnames) or ','.join(container_ids),
                                netname=netname or network_id)
 
-    def verify(self, container_id=None, network_id=None):
-        if not container_id or not network_id:
-            raise TaskException(errno.EINVAL, 'Both container and network must be specified')
+    def verify(self, container_ids=None, network_id=None):
+        if not container_ids or not network_id:
+            raise TaskException(errno.EINVAL, 'Both container(s) and network must be specified')
         hostname = None
         try:
-            hostname = self.dispatcher.call_sync('containerd.docker.host_name_by_container_id', container_id)
+            hostname = self.dispatcher.call_sync('containerd.docker.host_name_by_container_id', container_ids[0])
         except RpcException:
             pass
 
@@ -1053,58 +1053,67 @@ class DockerNetworkConnectTask(DockerBaseTask):
         else:
             return ['docker']
 
-    def run(self, container_id, network_id):
-        container = self.dispatcher.call_sync('docker.container.query', [('id', '=', container_id)], {'single': True})
+    def run(self, container_ids, network_id):
+        for id in container_ids:
+            if not self.datastore.exists('docker.containers', ('id', '=', id)):
+                raise TaskException(errno.ENOENT, 'Docker container {0} not found'.format(id))
+
         network = self.dispatcher.call_sync('docker.network.query', [('id', '=', network_id)], {'single': True})
-        if not container:
-            raise TaskException(errno.ENOENT, 'Docker container {0} does not exist'.format(container['names'][0]))
-        if not container.get('running'):
-            raise TaskException(errno.ENOENT, 'Docker container {0} is stopped'.format(container['names'][0]))
         if not network:
             raise TaskException(errno.ENOENT, 'Docker network {0} does not exist'.format(network['name']))
 
         try:
-            self.dispatcher.call_sync('containerd.docker.host_name_by_container_id', container_id)
+            self.dispatcher.call_sync('containerd.docker.host_name_by_container_id', container_ids[0])
         except RpcException:
-            _, host_name = self.get_container_name_and_vm_name(container_id)
+            _, host_name = self.get_container_name_and_vm_name(container_ids[0])
             raise TaskException(
                 errno.EINVAL,
                 'Docker Host {0} is currently unreachable.'.format(host_name or '')
             )
 
-        self.dispatcher.exec_and_wait_for_event(
-            'docker.container.changed',
-            lambda args: args['operation'] == 'update' and container_id in args['ids'],
-            lambda: self.dispatcher.call_sync(
-                'containerd.docker.connect_container_to_network', container_id, network_id),
-            600
-        )
+        containers = [c for c in self.dispatcher.call_sync(
+            'docker.container.query',
+            [('id', 'in', container_ids)],
+            {'select': ['id', 'name', 'running']}
+        )]
+        for _, cname, crunning in containers:
+            if not crunning:
+                raise TaskException(errno.ENOENT, 'Docker container {0} is stopped'.format(cname))
+
+        for cid, _, _ in containers:
+            self.dispatcher.exec_and_wait_for_event(
+                'docker.container.changed',
+                lambda args: args['operation'] == 'update' and cid in args['ids'],
+                lambda: self.dispatcher.call_sync(
+                    'containerd.docker.connect_container_to_network', cid, network_id),
+                600
+            )
 
 
-@description('Disconnects container from a network')
-@accepts(str, str)
+@description('Disconnects selected containers from a network')
+@accepts(h.array(str), str)
 class DockerNetworkDisconnectTask(DockerBaseTask):
     @classmethod
     def early_describe(cls):
-        return 'Disconnecting container from network'
+        return 'Disconnecting containers from network'
 
-    def describe(self, container_id, network_id):
-        contname = self.dispatcher.call_sync(
-            'docker.container.query', [('id', '=', container_id)], {'single': True, 'select': 'names.0'}
+    def describe(self, container_ids, network_id):
+        contnames = self.dispatcher.call_sync(
+            'docker.container.query', [('id', 'in', container_ids)], {'select': 'name'}
         )
         netname = self.dispatcher.call_sync(
             'docker.network.query', [('id', '=', network_id)], {'single': True, 'select': 'name'}
         )
-        return TaskDescription('Disconnecting container {contname} from network {netname}',
-                               contname=contname or container_id,
+        return TaskDescription('Disconnecting containers {contnames} from network {netname}',
+                               contnames=','.join(contnames) or ','.join(container_ids),
                                netname=netname or network_id)
 
-    def verify(self, container_id=None, network_id=None):
-        if not container_id or not network_id:
-            raise TaskException(errno.EINVAL, 'Both container and network must be specified')
+    def verify(self, container_ids=None, network_id=None):
+        if not container_ids or not network_id:
+            raise TaskException(errno.EINVAL, 'Both container(s) and network must be specified')
         hostname = None
         try:
-            hostname = self.dispatcher.call_sync('containerd.docker.host_name_by_container_id', container_id)
+            hostname = self.dispatcher.call_sync('containerd.docker.host_name_by_container_id', container_ids[0])
         except RpcException:
             pass
 
@@ -1113,32 +1122,41 @@ class DockerNetworkDisconnectTask(DockerBaseTask):
         else:
             return ['docker']
 
-    def run(self, container_id, network_id):
-        container = self.dispatcher.call_sync('docker.container.query', [('id', '=', container_id)], {'single': True})
+    def run(self, container_ids, network_id):
+        for id in container_ids:
+            if not self.datastore.exists('docker.containers', ('id', '=', id)):
+                raise TaskException(errno.ENOENT, 'Docker container {0} does not exist'.format(id))
+
         network = self.dispatcher.call_sync('docker.network.query', [('id', '=', network_id)], {'single': True})
-        if not container:
-            raise TaskException(errno.ENOENT, 'Docker container {0} does not exist'.format(container['names'][0]))
-        if not container.get('running'):
-            raise TaskException(errno.ENOENT, 'Docker container {0} is stopped'.format(container['names'][0]))
         if not network:
             raise TaskException(errno.ENOENT, 'Docker network {0} does not exist'.format(network['name']))
 
         try:
-            self.dispatcher.call_sync('containerd.docker.host_name_by_container_id', container_id)
+            self.dispatcher.call_sync('containerd.docker.host_name_by_container_id', container_ids[0])
         except RpcException:
-            _, host_name = self.get_container_name_and_vm_name(container_id)
+            _, host_name = self.get_container_name_and_vm_name(container_ids[0])
             raise TaskException(
                 errno.EINVAL,
                 'Docker Host {0} is currently unreachable.'.format(host_name or '')
             )
 
-        self.dispatcher.exec_and_wait_for_event(
-            'docker.container.changed',
-            lambda args: args['operation'] == 'update' and container_id in args['ids'],
-            lambda: self.dispatcher.call_sync(
-                'containerd.docker.disconnect_container_from_network', container_id, network_id),
-            600
-        )
+        containers = [c for c in self.dispatcher.call_sync(
+            'docker.container.query',
+            [('id', 'in', container_ids)],
+            {'select': ['id', 'name', 'running']}
+        )]
+        for _, cname, crunning in containers:
+            if not crunning:
+                raise TaskException(errno.ENOENT, 'Docker container {0} is stopped'.format(cname))
+
+        for cid, _, _ in containers:
+            self.dispatcher.exec_and_wait_for_event(
+                'docker.container.changed',
+                lambda args: args['operation'] == 'update' and cid in args['ids'],
+                lambda: self.dispatcher.call_sync(
+                    'containerd.docker.disconnect_container_from_network', cid, network_id),
+                600
+            )
 
 
 @description('Pulls a selected container image from Docker Hub and caches it on specified Docker host')

--- a/src/dispatcher/plugins/DockerPlugin.py
+++ b/src/dispatcher/plugins/DockerPlugin.py
@@ -1021,6 +1021,9 @@ class DockerNetworkDeleteTask(DockerBaseTask):
         if not self.datastore.exists('docker.networks', ('id', '=', id)):
             raise TaskException(errno.ENOENT, 'Docker network {0} does not exist'.format(id))
 
+        if self.dispatcher.call_sync('docker.network.query', [('id', '=', id)], {'select': 'containers', 'single': True}):
+            raise TaskException(errno.EINVAL, 'Cannot delete network "{0}" with connected containers'.format(id))
+
         try:
             self.dispatcher.call_sync('containerd.docker.host_name_by_network_id', id)
         except RpcException:


### PR DESCRIPTION
plus containers connected to networks are now displayed regardless of 'running' status for consistent view of topology.