### PR TITLE
SupportPlugin reworked + python-redmine port added to the build

### DIFF
--- a/nas_ports/devel/py-redmine/Makefile
+++ b/nas_ports/devel/py-redmine/Makefile
@@ -1,0 +1,15 @@
+# $FreeBSD$
+
+PORTNAME=	python-redmine
+PORTVERSION=	1.5.1
+CATEGORIES=	devel python
+MASTER_SITES=	CHEESESHOP
+PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+
+MAINTAINER=	dev@ixsystems.com
+COMMENT=	Python client for Redmine
+
+USES=		python
+USE_PYTHON=	autoplist distutils
+
+.include <bsd.port.mk>

--- a/nas_ports/devel/py-redmine/distinfo
+++ b/nas_ports/devel/py-redmine/distinfo
@@ -1,0 +1,2 @@
+SHA256 (python-redmine-1.5.1.tar.gz) = 8a2ba7292693579656434e74817f7308e24e76ca05cf179a7645420f1203edcd
+SIZE (python-redmine-1.5.1.tar.gz) = 465595

--- a/nas_ports/devel/py-redmine/pkg-descr
+++ b/nas_ports/devel/py-redmine/pkg-descr
@@ -1,0 +1,3 @@
+Python lib for Redmine
+
+WWW: https://github.com/maxtepkeev/python-redmine

--- a/nas_ports/freenas/freenas-dispatcher/Makefile
+++ b/nas_ports/freenas/freenas-dispatcher/Makefile
@@ -33,6 +33,7 @@ RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}argh>0:${PORTSDIR}/devel/py-argh \
 		${PYTHON_PKGNAMEPREFIX}dockerhub>0:${PORTSDIR}/freenas/py-dockerhub \
 		${PYTHON_PKGNAMEPREFIX}dockerfile-parse>0:${PORTSDIR}/devel/py-dockerfile-parse \
 		${PYTHON_PKGNAMEPREFIX}python-consul>0:${PORTSDIR}/devel/py-consul \
+		${PYTHON_PKGNAMEPREFIX}python-redmine>0:${PORTSDIR}/devel/py-redmine \
 		${PYTHON_PKGNAMEPREFIX}sortedcontainers>0:${PORTSDIR}/devel/py-sortedcontainers \
 		${PYTHON_PKGNAMEPREFIX}freenas.dispatcher>0:${PORTSDIR}/freenas/py-freenas.dispatcher \
 		${PYTHON_PKGNAMEPREFIX}libusb1>0:${PORTSDIR}/devel/py-libusb1 \


### PR DESCRIPTION
Since support-proxy is too error prone it is better to use redmine python bindings instead.
Category fetching will be reworked later on (I need to find out a secure way to do that)