### PR TITLE
support for 'host' and 'none' container networking mode

### DIFF
--- a/src/containerd/src/main.py
+++ b/src/containerd/src/main.py
@@ -1731,7 +1731,6 @@ class DockerService(RpcService):
         labels = {
             'org.freenas.autostart': bool_to_truefalse(container.get('autostart')),
             'org.freenas.expose-ports-at-host': bool_to_truefalse(container.get('expose_ports')),
-            'org.freenas.primary-network-mode': primary_network_mode,
             'org.freenas.dhcp': bool_to_truefalse(dhcp_enabled),
         }
 

--- a/src/containerd/src/main.py
+++ b/src/containerd/src/main.py
@@ -958,11 +958,14 @@ class DockerHost(object):
                             if alert:
                                 self.context.client.call_sync('alert.cancel', alert['id'])
 
-                            labels = details['Config']['Labels']
-                            if not truefalse_to_bool(labels.get('org.freenas.expose-ports-at-host')):
+                            expose_ports, primary_network_mode = self.context.client.call_sync(
+                                'docker.container.query',
+                                [('id', '=', ev['id'])],
+                                {'select': ['expose_ports', 'primary_network_mode'], 'single': True}
+                            )
+                            if not expose_ports:
                                 continue
-
-                            if truefalse_to_bool(labels.get('org.freenas.bridged')):
+                            if primary_network_mode != 'NAT':
                                 continue
 
                             self.logger.debug('Redirecting container {0} ports on host firewall'.format(ev['id']))

--- a/src/containerd/src/main.py
+++ b/src/containerd/src/main.py
@@ -1399,7 +1399,10 @@ class DockerService(RpcService):
 
         if labels.get('org.freenas.immutable'):
             for l in labels.get('org.freenas.immutable').split(','):
-                result['immutable'].append(DOCKER_LABELS_MAP[l].get('preset'))
+                try:
+                    result['immutable'].append(DOCKER_LABELS_MAP[l].get('preset'))
+                except KeyError:
+                    pass
 
         if labels.get('org.freenas.port-mappings'):
             for mapping in labels.get('org.freenas.port-mappings').split(','):

--- a/src/dispatcher/plugins/DockerPlugin.py
+++ b/src/dispatcher/plugins/DockerPlugin.py
@@ -2437,6 +2437,7 @@ def _init(dispatcher, plugin):
                 'items': {'type': 'string'}
             },
             'privileged': {'type': 'boolean'},
+            'primary_network_mode': {'oneOf': [{'$ref': 'DockerContainerNetworkMode'}, {'type': 'null'}]},
             'networks': {
                 'type': 'array',
                 'items': {'type': 'string'}
@@ -2444,11 +2445,15 @@ def _init(dispatcher, plugin):
         }
     })
 
+    plugin.register_schema_definition('DockerContainerNetworkMode', {
+        'type': 'string',
+        'enum': ['NAT', 'BRIDGED', 'HOST', 'NONE']
+    })
+
     plugin.register_schema_definition('DockerContainerBridge', {
         'type': 'object',
         'additionalProperties': False,
         'properties': {
-            'enable': {'type': 'boolean'},
             'dhcp': {'type': 'boolean'},
             'address': {'type': ['string', 'null']},
             'macaddress': {'type': ['string', 'null']}

--- a/src/dispatcher/plugins/DockerPlugin.py
+++ b/src/dispatcher/plugins/DockerPlugin.py
@@ -153,13 +153,13 @@ class DockerContainerProvider(Provider):
             return self.dispatcher.call_sync('docker.container.create_exec', id, '/bin/sh')
 
 
-@description('Provides information about Docker networks')
+@description('Provides information about Docker user-defined networks')
 class DockerNetworkProvider(Provider):
-    @description('Returns information about Docker networks')
+    @description('Returns information about Docker user-defined networks')
     @query('DockerNetwork')
     @generator
     def query(self, filter=None, params=None):
-        hide_builtin_networks = [('name', 'nin', ('bridge', 'external'))]
+        hide_builtin_networks = [('name', 'nin', ('bridge', 'external', 'host', 'none'))]
         if filter:
             filter.extend(hide_builtin_networks)
         else:

--- a/src/dispatcher/plugins/DockerPlugin.py
+++ b/src/dispatcher/plugins/DockerPlugin.py
@@ -496,7 +496,10 @@ class DockerContainerCreateTask(DockerBaseTask):
                 )
 
         bridge = container.get('bridge')
-        if bridge.get('enable') and not (bridge.get('dhcp') or bridge.get('address')):
+        network_mode = container.get('primary_network_mode')
+        bridge_enabled = network_mode == 'BRIDGED'
+
+        if bridge_enabled and not (bridge.get('dhcp') or bridge.get('address')):
             raise VerifyException(
                 errno.EINVAL,
                 'Either dhcp or static address must be selected for bridged container'
@@ -525,6 +528,7 @@ class DockerContainerCreateTask(DockerBaseTask):
             'privileged': False,
             'capabilities_add': [],
             'capabilities_drop': [],
+            'primary_network_mode': 'NAT',
             'networks': [],
         })
 
@@ -621,7 +625,9 @@ class DockerContainerUpdateTask(DockerBaseTask):
                 )
 
         bridge = updated_fields.get('bridge', {})
-        if bridge.get('enable') and not (bridge.get('dhcp') or bridge.get('address')):
+        network_mode = updated_fields.get('primary_network_mode')
+        bridge_enabled = network_mode == 'BRIDGED'
+        if bridge_enabled and not (bridge.get('dhcp') or bridge.get('address')):
             raise VerifyException(
                 errno.EINVAL,
                 'Either dhcp or static address must be selected for bridged container'

--- a/src/dispatcher/plugins/DockerPlugin.py
+++ b/src/dispatcher/plugins/DockerPlugin.py
@@ -505,6 +505,13 @@ class DockerContainerCreateTask(DockerBaseTask):
                 'Either dhcp or static address must be selected for bridged container'
             )
 
+        if network_mode in ('HOST', 'NONE') and container.get('networks'):
+            raise VerifyException(
+                errno.EINVAL,
+                'Cannot connect networks to container with primary network mode: {0}'.format(network_mode)
+            )
+
+
         if hostname:
             return ['docker:{0}'.format(hostname)]
         else:
@@ -631,6 +638,13 @@ class DockerContainerUpdateTask(DockerBaseTask):
             raise VerifyException(
                 errno.EINVAL,
                 'Either dhcp or static address must be selected for bridged container'
+            )
+
+        networks = updated_fields.get('networks') or container.get('networks')
+        if network_mode in ('HOST', 'NONE') and networks:
+            raise VerifyException(
+                errno.EINVAL,
+                'Cannot connect networks to container with primary network mode: {0}'.format(network_mode)
             )
 
         if 'running' in updated_fields:


### PR DESCRIPTION
This required also removing the 'org.freenas.bridged' label and adding 'org.freenas.primary-network-mode' and their respective properties.