### PR TITLE
Fix validate_system Dialog.MessagdeBox typo

### DIFF
--- a/src/freenas-installer/installer/Menu.py
+++ b/src/freenas-installer/installer/Menu.py
@@ -331,7 +331,7 @@ def do_install():
     SetProject(args.project)
     
     if validate_system() is False:
-        Dialog.MessagdeBox(Title(),
+        Dialog.MessageBox(Title(),
                            "\nSystem memory is too small.  Minimum memory size is 8Gbytes",
                            height=10, width=45).run()
         return


### PR DESCRIPTION
If hardware requirements do not meet a valid system it tries to create a dialog and fails. 